### PR TITLE
Fix inability to login

### DIFF
--- a/com.parsecgaming.parsec.yml
+++ b/com.parsecgaming.parsec.yml
@@ -71,7 +71,7 @@ modules:
           # The appdata.json is a file provided by parsec describing meta-information
           # for the parsecd-*.so. Without this file present in the home directory
           # parsec will refuse to start.
-          - "[ ! -e $HOME/appdata.json ] && ln -s /app/extra/share/parsec/skel/appdata.json $HOME/appdata.json"
+          - "cp /app/extra/share/parsec/skel/appdata.json $HOME/appdata.json"
           - "PARSEC_LIB=\"$(basename /app/extra/share/parsec/skel/parsecd-*.so)\""
           - "rm -f $HOME/*.so"
           - "ln -s \"/app/extra/share/parsec/skel/${PARSEC_LIB}\" \"$HOME/${PARSEC_LIB}\""


### PR DESCRIPTION
Parsec refused to start due to appdata forcing the version delivered by
the `.deb`. Sadly parsec doesn't provide proper package-based upgrades
and instead upgrades itself. Oddly enough, it doesn't take it well, when
the appdata definition is kept static or absent.

This patch fixes the problem, that prevents users from logging into the
service.

fixes #2 