### PR TITLE
Add workaround for wayland support

### DIFF
--- a/com.parsecgaming.parsec.yml
+++ b/com.parsecgaming.parsec.yml
@@ -8,8 +8,8 @@ copy-icon: true
 separate-locales: false
 finish-args:
   - "--share=ipc"
-  - "--socket=wayland"
-  - "--socket=fallback-x11"
+  # Workaround for broken wayland support
+  - "--socket=x11"
   - "--socket=pulseaudio"
   # As a game streaming service, network is obviously mendatory
   - "--share=network"


### PR DESCRIPTION
This patch replaces wayland support with classic x11 due to broken
support from upstream since build 150-64.

There is currently no information available of when or why this broke,
but it fails.

This patch provides a workaround for the issue in https://github.com/flathub/com.parsecgaming.parsec/issues/6.