### PR TITLE
Upgrade runtime to 20.08

### DIFF
--- a/com.parsecgaming.parsec.yml
+++ b/com.parsecgaming.parsec.yml
@@ -1,7 +1,7 @@
 ---
 app-id: "com.parsecgaming.parsec"
 runtime: "org.freedesktop.Platform"
-runtime-version: "19.08"
+runtime-version: "20.08"
 sdk: "org.freedesktop.Sdk"
 command: "parsec"
 copy-icon: true


### PR DESCRIPTION
The runtime 19.08 is already quite old, this patch should update it to
20.08. This might solves some other underlying issues.