### PR TITLE
Update runtime to 22.08

### DIFF
--- a/com.parsecgaming.parsec.yml
+++ b/com.parsecgaming.parsec.yml
@@ -1,7 +1,7 @@
 ---
 app-id: "com.parsecgaming.parsec"
 runtime: "org.freedesktop.Platform"
-runtime-version: "21.08"
+runtime-version: "22.08"
 sdk: "org.freedesktop.Sdk"
 command: "parsec"
 copy-icon: true


### PR DESCRIPTION
Parsec won't start otherwise, updating the runtime fixed the issue