### PR TITLE
chore: Upgrade to runtime 23.08

### DIFF
--- a/com.parsecgaming.parsec.yml
+++ b/com.parsecgaming.parsec.yml
@@ -1,6 +1,6 @@
 app-id: com.parsecgaming.parsec
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: parsec
 copy-icon: true
@@ -28,7 +28,7 @@ add-extensions:
     autodelete: false
     autodownload: true
     directory: lib/ffmpeg
-    version: '21.08'
+    version: '23.08'
 cleanup-commands:
   - mkdir -p /app/lib/ffmpeg
   - mv /app/lib/libjpeg.so.8.* /app/lib/libjpeg.so.8
@@ -76,6 +76,7 @@ modules:
     build-commands:
       - install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin
       - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib
+      - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libsframe*.so.* -t ${FLATPAK_DEST}/lib
       - install -Dm755 parsec.sh ${FLATPAK_DEST}/bin/parsec
       - install -Dm755 apply_extra ${FLATPAK_DEST}/bin/apply_extra
       - install -Dm644 com.parsecgaming.parsec.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png


### PR DESCRIPTION
This is a potentially breaking change and needs quite some testing. I hope some people from the community can help validate this.

The current runtime 21.08 will go EOL very soon.