### PR TITLE
revert runtime version to 21.08

### DIFF
--- a/com.parsecgaming.parsec.yml
+++ b/com.parsecgaming.parsec.yml
@@ -1,6 +1,6 @@
 app-id: com.parsecgaming.parsec
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: parsec
 copy-icon: true
@@ -28,7 +28,7 @@ add-extensions:
     autodelete: false
     autodownload: true
     directory: lib/ffmpeg
-    version: '23.08'
+    version: '21.08'
 cleanup-commands:
   - mkdir -p /app/lib/ffmpeg
   - mv /app/lib/libjpeg.so.8.* /app/lib/libjpeg.so.8


### PR DESCRIPTION
updating to 23.08 broke connecting to remote hosts due to newer runtimes shipping too newer version of libavcodec (parsec expects libavcodec58 only)